### PR TITLE
Implement OnRegister LoadWhen enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.1.0] - 23/03/2024
+
+### Added
+
+- Implemented `OnRegister` LoadWhen enum value and behaviour to handle it.
+
 ## [1.0.1] - 23/03/2024
 
 ### Fixed

--- a/LethalModDataLib/Enums/LoadWhen.cs
+++ b/LethalModDataLib/Enums/LoadWhen.cs
@@ -21,5 +21,5 @@ public enum LoadWhen
     /// <summary>
     ///     Load as soon as the field/property is registered by the API.
     /// </summary>
-    Immediately = 2
+    OnRegister = 2
 }

--- a/LethalModDataLib/Features/ModDataHandler.cs
+++ b/LethalModDataLib/Features/ModDataHandler.cs
@@ -88,6 +88,8 @@ public static class ModDataHandler
         ModDataValues[modDataKey].BaseKey ??= ModDataHelper.GenerateBaseKey(type, guid);
         LethalModDataLib.Logger?.LogDebug(
             $"Added field or property with name {modDataKey.Name} from {type.AssemblyQualifiedName} to the mod data system!");
+
+        if (ModDataValues[modDataKey].LoadWhen.HasFlag(LoadWhen.OnRegister)) HandleLoadModData(modDataKey);
     }
 
     #region Initialisation


### PR DESCRIPTION
Allows for loading of data (if any exist) immediately upon registration of the attributed field or property with the ModData system. Should make the attribute system a lot easier to work with.