### PR TITLE
Feat reset when

### DIFF
--- a/LethalModDataLib/Attributes/ModDataAttribute.cs
+++ b/LethalModDataLib/Attributes/ModDataAttribute.cs
@@ -15,16 +15,19 @@ public class ModDataAttribute : Attribute
     /// <param name="saveWhen"> When to save the field. <see cref="SaveWhen" /> </param>
     /// <param name="loadWhen"> When to load the field. <see cref="LoadWhen" /> </param>
     /// <param name="saveLocation"> Where to save the field. <see cref="SaveLocation" /> </param>
+    /// <param name="resetWhen"> When to reset the field. <see cref="ResetWhen" /> </param>
     /// <param name="baseKey">
     ///     Key prefix for the field. The ModData system will automatically set this to the mod's GUID
     ///     unless it is set manually.
     /// </param>
     public ModDataAttribute(SaveWhen saveWhen = SaveWhen.OnSave, LoadWhen loadWhen = LoadWhen.OnLoad,
-        SaveLocation saveLocation = SaveLocation.CurrentSave, string? baseKey = null)
+        SaveLocation saveLocation = SaveLocation.CurrentSave, ResetWhen resetWhen = ResetWhen.Manual,
+        string? baseKey = null)
     {
         SaveWhen = saveWhen;
         LoadWhen = loadWhen;
         SaveLocation = saveLocation;
+        ResetWhen = resetWhen;
         BaseKey = baseKey;
     }
 
@@ -37,23 +40,28 @@ public class ModDataAttribute : Attribute
     }
 
     /// <summary>
-    ///     When to load the field.
+    ///     When to load the field or property.
     /// </summary>
     public LoadWhen LoadWhen { get; set; } = LoadWhen.OnLoad;
 
     /// <summary>
-    ///     When to save the field.
+    ///     When to save the field or property.
     /// </summary>
     public SaveWhen SaveWhen { get; set; } = SaveWhen.OnSave;
 
     /// <summary>
-    ///     Where to save the field.
+    ///     When to reset the field or property.
+    /// </summary>
+    public ResetWhen ResetWhen { get; set; } = ResetWhen.Manual;
+
+    /// <summary>
+    ///     Where to save the field or property.
     /// </summary>
     public SaveLocation SaveLocation { get; set; } = SaveLocation.CurrentSave;
 
     /// <summary>
-    ///     Key prefix for the field. The ModData system will automatically set this to the mod's GUID unless it is set
-    ///     manually.
+    ///     Key prefix for the field or property. The ModData system will automatically set this to the mod's GUID unless it is
+    ///     set manually.
     /// </summary>
     public string? BaseKey { get; set; }
 }

--- a/LethalModDataLib/Enums/ResetWhen.cs
+++ b/LethalModDataLib/Enums/ResetWhen.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace LethalModDataLib.Enums;
+
+/// <summary>
+///     Enum to specify when to reset fields/properties marked with <see cref="Attributes.ModDataAttribute" />.
+/// </summary>
+[Flags]
+public enum ResetWhen
+{
+    /// <summary>
+    ///     No automatic reset. Modder is responsible for resetting the field/property when needed.
+    /// </summary>
+    Manual = 0,
+
+    /// <summary>
+    ///     Reset when we load or create a new save (before loading mod data).
+    /// </summary>
+    OnLoad = 1
+}

--- a/LethalModDataLib/Enums/ResetWhen.cs
+++ b/LethalModDataLib/Enums/ResetWhen.cs
@@ -14,7 +14,7 @@ public enum ResetWhen
     Manual = 0,
 
     /// <summary>
-    ///     Reset when we load or create a new save (before loading mod data).
+    ///     Reset the field/property when a game over happens (quota not reached).
     /// </summary>
-    OnLoad = 1
+    OnGameOver = 1
 }

--- a/LethalModDataLib/Events/SaveLoadEvents.cs
+++ b/LethalModDataLib/Events/SaveLoadEvents.cs
@@ -22,6 +22,11 @@ public static class SaveLoadEvents
     public delegate void PostLoadGameEventHandler(bool isChallenge, string saveFileName);
 
     /// <summary>
+    ///     Called after the game resets its saved game values. (This only happens after a game over)
+    /// </summary>
+    public delegate void PostResetSavedGameValuesEventHandler();
+
+    /// <summary>
     ///     Called after the game has been saved.
     /// </summary>
     public delegate void PostSaveGameEventHandler(bool isChallenge, string saveFileName);
@@ -78,5 +83,18 @@ public static class SaveLoadEvents
     internal static void OnPostDeleteSave(string saveFileName)
     {
         PostDeleteSaveEvent?.Invoke(saveFileName);
+    }
+
+    /// <summary>
+    ///     Called after the game resets its saved game values. (This only happens after a game over)
+    /// </summary>
+    public static event PostResetSavedGameValuesEventHandler? PostResetSavedGameValuesEvent;
+
+    /// <summary>
+    ///     Called after the game resets its saved game values. (This only happens after a game over)
+    /// </summary>
+    internal static void OnPostResetSavedGameValues()
+    {
+        PostResetSavedGameValuesEvent?.Invoke();
     }
 }

--- a/LethalModDataLib/Features/ModDataHandler.cs
+++ b/LethalModDataLib/Features/ModDataHandler.cs
@@ -123,7 +123,7 @@ public static class ModDataHandler
     ///     Saves the mod data attributed object.
     /// </summary>
     /// <param name="modDataKey"> ModDataKey of the object to save. </param>
-    internal static void HandleSaveModData(IModDataKey modDataKey)
+    internal static void HandleSaveModData(this IModDataKey modDataKey)
     {
         if (!SaveLoadHandler.SaveData(modDataKey))
             LethalModDataLib.Logger?.LogWarning(
@@ -134,7 +134,7 @@ public static class ModDataHandler
     ///     Loads the mod data attributed object.
     /// </summary>
     /// <param name="modDataKey"> ModDataKey of the object to load. </param>
-    internal static void HandleLoadModData(IModDataKey modDataKey)
+    internal static void HandleLoadModData(this IModDataKey modDataKey)
     {
         if (!SaveLoadHandler.LoadData(modDataKey))
             LethalModDataLib.Logger?.LogWarning(
@@ -173,7 +173,7 @@ public static class ModDataHandler
     {
         foreach (var modDataKey in ModDataValues.Keys.Where(modDataKey =>
                      ModDataValues[modDataKey].SaveWhen.HasFlag(SaveWhen.OnSave)))
-            HandleSaveModData(modDataKey);
+            modDataKey.HandleSaveModData();
     }
 
     /// <summary>
@@ -183,7 +183,7 @@ public static class ModDataHandler
     {
         foreach (var modDataKey in ModDataValues.Keys.Where(modDataKey =>
                      ModDataValues[modDataKey].SaveWhen.HasFlag(SaveWhen.OnAutoSave)))
-            HandleSaveModData(modDataKey);
+            modDataKey.HandleSaveModData();
     }
 
     /// <summary>
@@ -193,7 +193,7 @@ public static class ModDataHandler
     {
         foreach (var modDataKey in ModDataValues.Keys.Where(modDataKey =>
                      ModDataValues[modDataKey].LoadWhen.HasFlag(LoadWhen.OnLoad)))
-            HandleLoadModData(modDataKey);
+            modDataKey.HandleLoadModData();
     }
 
     /// <summary>

--- a/LethalModDataLib/Features/ModDataHandler.cs
+++ b/LethalModDataLib/Features/ModDataHandler.cs
@@ -84,12 +84,15 @@ public static class ModDataHandler
             return;
         }
 
-        ModDataValues.Add(modDataKey, new ModDataValue(modDataKey.GetModDataAttribute(), keySuffix));
+        modDataKey.TryGetValue(out var originalValue);
+
+        ModDataValues.Add(modDataKey, new ModDataValue(modDataKey.GetModDataAttribute(), keySuffix, originalValue));
         ModDataValues[modDataKey].BaseKey ??= ModDataHelper.GenerateBaseKey(type, guid);
         LethalModDataLib.Logger?.LogDebug(
             $"Added field or property with name {modDataKey.Name} from {type.AssemblyQualifiedName} to the mod data system!");
 
-        if (ModDataValues[modDataKey].LoadWhen.HasFlag(LoadWhen.OnRegister)) HandleLoadModData(modDataKey);
+        if (ModDataValues[modDataKey].LoadWhen.HasFlag(LoadWhen.OnRegister))
+            HandleLoadModData(modDataKey);
     }
 
     #region Initialisation

--- a/LethalModDataLib/Features/ModDataHandler.cs
+++ b/LethalModDataLib/Features/ModDataHandler.cs
@@ -205,6 +205,9 @@ public static class ModDataHandler
         DeleteModDataFile(filePath);
     }
 
+    /// <summary>
+    ///     Resets all mod data attributed objects that have their ResetWhen set to OnGameOver.
+    /// </summary>
     private static void OnGameOver()
     {
         foreach (var modDataKey in ModDataValues.Keys.Where(modDataKey =>

--- a/LethalModDataLib/Features/ModDataHandler.cs
+++ b/LethalModDataLib/Features/ModDataHandler.cs
@@ -110,6 +110,7 @@ public static class ModDataHandler
         SaveLoadEvents.PostAutoSaveEvent += OnAutoSave;
         SaveLoadEvents.PostLoadGameEvent += OnLoad;
         SaveLoadEvents.PostDeleteSaveEvent += OnDeleteSave;
+        SaveLoadEvents.PostResetSavedGameValuesEvent += OnGameOver;
 
         LethalModDataLib.Logger?.LogInfo("ModDataHandler initialised!");
     }
@@ -158,6 +159,13 @@ public static class ModDataHandler
         }
     }
 
+    private static void ResetModData(this IModDataKey modDataKey)
+    {
+        if (!modDataKey.TrySetValue(ModDataValues[modDataKey].OriginalValue))
+            LethalModDataLib.Logger?.LogWarning(
+                $"Failed to reset field or property {modDataKey.Name} from {modDataKey.AssemblyQualifiedName}!");
+    }
+
     /// <summary>
     ///     Saves all mod data attributed objects that have their SaveWhen set to OnSave.
     /// </summary>
@@ -195,6 +203,13 @@ public static class ModDataHandler
     private static void OnDeleteSave(string filePath)
     {
         DeleteModDataFile(filePath);
+    }
+
+    private static void OnGameOver()
+    {
+        foreach (var modDataKey in ModDataValues.Keys.Where(modDataKey =>
+                     ModDataValues[modDataKey].ResetWhen.HasFlag(ResetWhen.OnGameOver)))
+            modDataKey.ResetModData();
     }
 
     #endregion

--- a/LethalModDataLib/Features/SaveLoadHandler.cs
+++ b/LethalModDataLib/Features/SaveLoadHandler.cs
@@ -120,10 +120,7 @@ public static class SaveLoadHandler
         var key = modDataKey.ToES3KeyString();
         var saveLocation = modDataValue.SaveLocation;
 
-        // If the field or property has a value, we'll use it as default in case no saved moddata is found
-        modDataKey.TryGetValue(out var currentValue);
-
-        var value = LoadData(key, saveLocation, autoAddGuid: false, defaultValue: currentValue);
+        var value = LoadData(key, saveLocation, autoAddGuid: false, defaultValue: modDataValue.OriginalValue);
 
         try
         {

--- a/LethalModDataLib/Features/SaveLoadHandler.cs
+++ b/LethalModDataLib/Features/SaveLoadHandler.cs
@@ -122,16 +122,6 @@ public static class SaveLoadHandler
 
         var value = LoadData(key, saveLocation, autoAddGuid: false, defaultValue: modDataValue.OriginalValue);
 
-        try
-        {
-            LethalModDataLib.Logger?.LogDebug(
-                $"Loaded value for property or field {modDataKey.Name}: {value}");
-        }
-        catch (Exception e)
-        {
-            // ignored in case the value can't be converted to a string
-        }
-
         if (modDataKey.TrySetValue(value))
             return true;
 
@@ -163,15 +153,6 @@ public static class SaveLoadHandler
         try
         {
             LethalModDataLib.Logger?.LogDebug($"Saving data to file {fileName} with key {key}...");
-
-            try
-            {
-                LethalModDataLib.Logger?.LogDebug($"Data to save: {data}");
-            }
-            catch (Exception e)
-            {
-                // ignored in case the data can't be converted to a string
-            }
 
             ES3.Save(key, data, fileName);
             return true;

--- a/LethalModDataLib/Models/ModDataValue.cs
+++ b/LethalModDataLib/Models/ModDataValue.cs
@@ -28,6 +28,11 @@ public record ModDataValue(ModDataAttribute ModDataAttribute, string? KeySuffix 
     public LoadWhen LoadWhen => ModDataAttribute.LoadWhen;
 
     /// <summary>
+    ///     When to reset the field.
+    /// </summary>
+    public ResetWhen ResetWhen => ModDataAttribute.ResetWhen;
+
+    /// <summary>
     ///     Where to save the field.
     /// </summary>
     public SaveLocation SaveLocation => ModDataAttribute.SaveLocation;

--- a/LethalModDataLib/Models/ModDataValue.cs
+++ b/LethalModDataLib/Models/ModDataValue.cs
@@ -6,7 +6,7 @@ namespace LethalModDataLib.Models;
 /// <summary>
 ///     Record used as value for ModDataFields and ModDataProperties dictionaries.
 /// </summary>
-public record ModDataValue(ModDataAttribute ModDataAttribute, string? KeySuffix = null)
+public record ModDataValue(ModDataAttribute ModDataAttribute, string? KeySuffix = null, object? OriginalValue = null)
 {
     /// <summary>
     ///     Base key for ES3.
@@ -36,4 +36,9 @@ public record ModDataValue(ModDataAttribute ModDataAttribute, string? KeySuffix 
     ///     Where to save the field.
     /// </summary>
     public SaveLocation SaveLocation => ModDataAttribute.SaveLocation;
+
+    /// <summary>
+    ///     Original value of the field.
+    /// </summary>
+    public object? OriginalValue { get; set; }
 }

--- a/LethalModDataLib/Models/ModDataValue.cs
+++ b/LethalModDataLib/Models/ModDataValue.cs
@@ -36,9 +36,4 @@ public record ModDataValue(ModDataAttribute ModDataAttribute, string? KeySuffix 
     ///     Where to save the field.
     /// </summary>
     public SaveLocation SaveLocation => ModDataAttribute.SaveLocation;
-
-    /// <summary>
-    ///     Original value of the field.
-    /// </summary>
-    public object? OriginalValue { get; set; }
 }

--- a/LethalModDataLib/Patches/GameNetworkManagerPatches.cs
+++ b/LethalModDataLib/Patches/GameNetworkManagerPatches.cs
@@ -22,4 +22,15 @@ internal static class GameNetworkManagerPatches
     {
         SaveLoadEvents.OnPostSaveGame(StartOfRound.Instance.isChallengeFile, __instance.currentSaveFileName);
     }
+
+    /// <summary>
+    ///     Called after the game resets its saved game values. (This only happens after a game over)
+    /// </summary>
+    /// <param name="__instance"> The <see cref="GameNetworkManager" /> instance. </param>
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(GameNetworkManager.ResetSavedGameValues))]
+    private static void PostResetSavedGameValues(GameNetworkManager __instance)
+    {
+        SaveLoadEvents.OnPostResetSavedGameValues();
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/MaxWasUnavailable/LethalModDataLib/issues/3

Items attributed with the ModData tag now store their initial value upon registration.

This original value is used when:
- One attempts to load a save with no moddata data for that item
- ResetWhen is triggered

ResetWhen currently has 2 values: Manual & OnGameOver

- Manual doesn't trigger anything (default)
- OnGameOver triggers a reset (to the original value) when a game over happens. (Specifically, when vanilla LC resets its saved data during the game over mechanics)